### PR TITLE
Sync repo with latest from st2-chatops-aliases master

### DIFF
--- a/actions/deploy-infrastructure.yaml
+++ b/actions/deploy-infrastructure.yaml
@@ -13,7 +13,7 @@ parameters:
   cmd:
     description: "Command to run"
     immutable: true
-    default: "ansible-playbook --connection=local -i /opt/omnia/plugins/inventory deploy-infrastructure-repo.yml"
+    default: "ansible-playbook deploy-infrastructure-repo.yml"
 
   cwd:
     description: "Working directory where the command will be executed in eg. chdir"

--- a/actions/lib/ansible-playbook.sh
+++ b/actions/lib/ansible-playbook.sh
@@ -5,7 +5,7 @@ STACK=$2
 LAYER=$3
 
 if [ -z $STACK ] ||  [ -z $LAYER ]; then
-  ansible-playbook --connection=local -i /opt/omnia/plugins/inventory $PLAYBOOK | tail -3 | head -1
+  ansible-playbook $PLAYBOOK | tr '{{' '-'
 else
-  ansible-playbook --connection=local -i /opt/omnia/plugins/inventory $PLAYBOOK -e stack=$STACK -e layer=$LAYER | tail -3 | head -1
+  ansible-playbook $PLAYBOOK -e stack=$STACK -e layer=$LAYER | tr '{{' '-'
 fi

--- a/actions/lib/ansible-stack-layer-version-repo-environment.sh
+++ b/actions/lib/ansible-stack-layer-version-repo-environment.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+
+PLAYBOOK=$1
+STACK=$2
+LAYER=$3
+VERSION=$4
+APP_REPO=$5
+ENVIRONMENT=$6
+
+
+if [ -z $PLAYBOOK ] ||  [ -z $STACK ] ||  [ -z $LAYER ] ||  [ -z $VERSION ] ||  [ -z $APP_REPO ] ||  [ -z $ENVIRONMENT ]; then
+  exit 1
+fi
+ansible-playbook $PLAYBOOK -e stack=$STACK -e layer=$LAYER -e version=$VERSION -e app_repo=$APP_REPO -e env=$ENVIRONMENT | tr '{{' '-'

--- a/actions/lib/ansible-stack-layer-version-repo.sh
+++ b/actions/lib/ansible-stack-layer-version-repo.sh
@@ -4,6 +4,10 @@ PLAYBOOK=$1
 STACK=$2
 LAYER=$3
 VERSION=$4
-REPO=$5
+APP_REPO=$5
 
-ansible-playbook --connection=local -i /opt/omnia/plugins/inventory $PLAYBOOK -e stack=$STACK -e layer=$LAYER -e version=$VERSION -e app_repo=$REPO 
+
+if [ -z $PLAYBOOK ] ||  [ -z $STACK ] ||  [ -z $LAYER ] ||  [ -z $VERSION ] ||  [ -z $APP_REPO ]; then
+  exit 1
+fi
+ansible-playbook $PLAYBOOK -e stack=$STACK -e layer=$LAYER -e version=$VERSION -e app_repo=$APP_REPO | tr '{{' '-'

--- a/actions/run-task-stack-layer-version-repo-environment.yaml
+++ b/actions/run-task-stack-layer-version-repo-environment.yaml
@@ -1,0 +1,65 @@
+---
+
+# st2 run st2-chatops-aliases.run_task_stack_layer_version_repo \
+# playbook=run-migrations.yml
+# stack=app layer=web version=develop \
+# app_repo='ssh://git@github.com/idyllicsoftware/GMR.git'
+# environment=[dev|stg|prod]
+
+name: "run_task_stack_layer_version_repo_environment"
+description:  "Run a task with task with setting stack, layer, version, repo, environment variables"
+runner_type: "local-shell-script"
+entry_point: "lib/ansible-stack-layer-version-repo-environment.sh"
+enabled: true
+parameters:
+  env:
+    default:
+      ANSIBLE_CONFIG: "/opt/omnia/infrastructure/config/remote_ansible.cfg"
+
+  cwd:
+    description: "Working directory where the command will be executed in eg. chdir"
+    type: string
+    default: "/opt/omnia/infrastructure/tasks"
+    immutable: true
+
+  playbook:
+    type: string
+    description: "playbook file"
+    required: true
+    position: 0
+
+  timeout:
+    description: "timeout"
+    type: integer
+    # 20 minutes
+    default: 1200
+
+  stack:
+    type: string
+    description: "stack"
+    required: true
+    position: 1
+
+  layer:
+    type: string
+    description: "layer"
+    required: true
+    position: 2
+
+  version:
+    type: string
+    description: "version"
+    required: true
+    position: 3
+
+  app_repo:
+    type: string
+    description: "app_repo"
+    required: true
+    position: 4
+
+  environment:
+    type: string
+    description: "omnia environment"
+    required: true
+    position: 5

--- a/actions/run-task-stack-layer-version-repo.yaml
+++ b/actions/run-task-stack-layer-version-repo.yaml
@@ -46,8 +46,8 @@ parameters:
     required: true
     position: 3
 
-  repo:
+  app_repo:
     type: string
-    description: "repo"
+    description: "app_repo"
     required: true
     position: 4

--- a/aliases/run-task-stack-layer-version-repo-environment.yaml
+++ b/aliases/run-task-stack-layer-version-repo-environment.yaml
@@ -1,0 +1,6 @@
+---
+name: "run_task_stack_layer_version_repo_environment"
+action_ref: "st2-chatops-aliases.run_task_stack_layer_version_repo_environment"
+description: "Run Ansible playbook with stack, layer, version, repo, and environment"
+formats:
+  - env-run {{ playbook }} stack {{ stack }} layer {{ layer }} version {{ version }} app_repo {{ app_repo }} environment {{ environment }}

--- a/aliases/run-task-stack-layer-version-repo.yaml
+++ b/aliases/run-task-stack-layer-version-repo.yaml
@@ -1,6 +1,6 @@
 ---
 name: "run_task_stack_layer_version_repo"
 action_ref: "st2-chatops-aliases.run_task_stack_layer_version_repo"
-description: "Pack code"
+description: "Run Ansible playbook with stack, layer, version, and repo"
 formats:
-  - run task {{ playbook }} stack {{ stack }} layer {{ layer }} version {{ version }} repo {{ repo }}
+  - go {{ playbook }} stack {{ stack }} layer {{ layer }} version {{ version }} app_repo {{ app_repo }}

--- a/aliases/run-task.yaml
+++ b/aliases/run-task.yaml
@@ -3,4 +3,4 @@ name: "run_task"
 action_ref: "st2-chatops-aliases.run_task"
 description: "Run task"
 formats:
-  - run task {{ playbook }}
+  - play task {{ playbook }}


### PR DESCRIPTION
This PR syncs a few stray commits from [st2-chatops-aliases](https://github.com/reactiveops/st2-chatops-aliases) `master` branch committed there after creating this cloned repo. This is the first step in shuttering the st2-chatops-aliases forked community repo and using this repo exclusively for our Stackstorm setups.

Boxed seems to have been using the `use-existing-dyn-inventory` branch on this repo. GMR has been using the st2-chatops-aliases repo `master` branch. With this sync up we can switch GMR over to this repo and delete the st2-chatops-aliases repo. We can decide how to handle Boxed's branch separately from this PR.
